### PR TITLE
feat: no_std and schemars support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "^1.0", default-features = false, features = [
     "derive",
     "alloc",
 ] }
-schemars = { version = "^0.8.3", optional = true }
+schemars = { version = "^0.8", optional = true }
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ schema = ["std", "dep:schemars"]
 unstable = ["serde/unstable"]
 
 [dependencies]
-serde = { version = "^1.0.103", default-features = false, features = [
+serde = { version = "^1.0", default-features = false, features = [
     "derive",
     "alloc",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,20 @@ readme = "README.md"
 keywords = ["serde", "wasm"]
 license = "MIT"
 
+[features]
+default = ["std"]
+
+std = []
+schema = ["std", "dep:schemars"]
+unstable = ["serde/unstable"]
+
 [dependencies]
-serde = "^1.0.0"
+serde = { version = "^1.0.103", default-features = false, features = [
+    "derive",
+    "alloc",
+] }
+schemars = { version = "^0.8.3", optional = true }
+
 
 [dev-dependencies]
 serde_derive = "^1.0.0"

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,10 +1,20 @@
-use serde::{de, forward_to_deserialize_any};
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
+use alloc::fmt;
+use alloc::vec::Vec;
+
+use alloc::boxed::Box;
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+use core::marker::PhantomData;
+
+#[cfg(feature = "unstable")]
+use core::error::Error;
+#[cfg(not(feature = "unstable"))]
 use std::error::Error;
-use std::fmt;
-use std::marker::PhantomData;
 
 use crate::Value;
+use serde::{de, forward_to_deserialize_any};
 
 #[derive(Debug)]
 pub enum Unexpected {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,19 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "unstable", feature(error_in_core))]
+
+#[cfg(test)]
+extern crate std;
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::hash::Hash;
+use core::hash::Hasher;
 use serde::Deserialize;
-use std::cmp::Ordering;
-use std::collections::BTreeMap;
-use std::hash::{Hash, Hasher};
 
 pub use de::*;
 pub use ser::*;
@@ -110,6 +122,17 @@ impl Ord for Value {
             (&Value::Bytes(ref v0), &Value::Bytes(ref v1)) => v0.cmp(v1),
             (v0, v1) => v0.discriminant().cmp(&v1.discriminant()),
         }
+    }
+}
+
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for Value {
+    fn schema_name() -> String {
+        "JSON".to_string()
+    }
+
+    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        schemars::schema::Schema::from(true)
     }
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,9 +1,19 @@
-use serde::ser;
-use std::collections::BTreeMap;
-use std::error::Error;
-use std::fmt;
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::fmt;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
 
 use crate::Value;
+#[cfg(feature = "unstable")]
+use core::error::Error;
+#[cfg(not(feature = "std"))]
+use core::marker::PhantomData;
+use serde::ser;
+
+#[cfg(not(feature = "unstable"))]
+use std::error::Error;
 
 #[derive(Debug)]
 pub enum SerializerError {


### PR DESCRIPTION

schemars with JsonSchema so can have value in tree of objects to send to CW contract

+

no_std similar like in https://github.com/CosmWasm/serde-json-wasm